### PR TITLE
Removes '/hello' route

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A simple dictionary app
 2. Start server (http://127.0.0.1:3000): `npm start`
 
 ## Routes
-- /hello
-- /define?word=banana
-- /add?word=things&definition=just+stuff
-- /add?word=things&definition=just+stuff+and+more+stuff&overwrite=1
-- /remove?word=things
+- `/index`
+- `/lookup?word=banana`
+- `/add?word=things&definition=just+stuff`
+- `/add?word=things&definition=just+stuff+and+more+stuff&overwrite=1`
+- `/remove?word=things`
 
 ## Tests
 - `npm run test`
-- `npm run nyan` **FUN WARNING**
 - `npm run coverage`
+- `npm run nyan` **FUN WARNING**

--- a/app/app.js
+++ b/app/app.js
@@ -16,10 +16,8 @@ var dictionary = new Dictionary( {
 
 // Routes
 app.get( '/', require( './route-index' ) );
-app.get( '/hello', require( './route-hello' ) );
 app.get( '/lookup', require( './route-lookup' )( dictionary ) );
 app.get( '/add', require( './route-add' )( dictionary ) );
 app.get( '/remove', require( './route-remove' )( dictionary ) );
-
 
 module.exports = app;

--- a/app/route-hello.js
+++ b/app/route-hello.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = function( req, res ) {
-    res.header( 'Content-Type', 'text/plain' );
-    res.send( 'Hello.' );
-};

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -35,18 +35,6 @@ writeTestDictionary( test_dictionary );
 process.env.NODE_ENV = 'test';
 var app = require( '../app/app.js' );
 
-
-describe( 'Test static paths', function() {
-    describe( 'Says hello', function() {
-        it( 'responds with plain text', function( done ) {
-            request( app )
-                .get( '/hello' )
-                .expect( 200, done );
-        } );
-    } );
-} );
-
-
 describe( 'Test /lookup', function() {
 
     for ( word in test_dictionary ) {


### PR DESCRIPTION
# Removes
1. `/hello` route from: app, README, and tests
## Conflict Heads-up

Once you merge in PR #3: I'm pretty sure there'll be two small conflicts to fix in this branch before GitHub's magic, green-colored merge-button at the bottom lights up.

---

@vyder: Out of habit, I named this branch with a prefix and slash (like `feature/`, `hotfix/`, `support/`, `bug/`, and so forth) followed by a short, descriptive name for the branch (replacing spaces with dashes).
- Have you experienced issues with `git` and branch names containing a `/` (slash)?
- Does `git checkout remove/hello-route` not function correctly for you?

Typically, I try to follow as closely as possible the so-called '[git flow](http://nvie.com/posts/a-successful-git-branching-model/)' pattern. It does appear that the pattern doesn't _necessitate_ using slashes, however, as part of one's branch-name prefixes. I've always under the impression that `git` views a `/` (slash) in a branch-name no differently than any other alphanumeric character. I could be wrong, of course.

Perhaps it's more a matter of aesthetics and preference than a technical limitation or issue with `git`?
